### PR TITLE
Specify a detail for the unit returned

### DIFF
--- a/docs/reference/transform/painless-examples.asciidoc
+++ b/docs/reference/transform/painless-examples.asciidoc
@@ -343,9 +343,9 @@ PUT _transform/data_log
 <1> To define the length of the sessions, we use a bucket script.
 <2> The bucket path is a map of script variables and their associated path to 
 the buckets you want to use for the variable. In this particular case, `min` and 
-`max` are variables mapped to `time_frame.gte.value` and `time_frame.lte.value`.
+`max` are variables mapped to `time_frame.gte.value` and `time_frame.lte.value`. `max` and `min` are of type `double`, and their values correspond to time in milliseconds.
 <3> Finally, the script substracts the start date of the session from the end 
-date which results in the duration of the session.
+date which results in the duration of the session. The unit time returned is in milliseconds.
 
 [[painless-count-http]]
 == Counting HTTP responses by using scripted metric aggregation


### PR DESCRIPTION
it wasn't obvious for me to figure it out, until I did some time consuming test to find that the unit is in milliseconds, better specify it explicitly I guess !

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
